### PR TITLE
remove duplicate /bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ Name = "nginx"
 # read only paths for the container
 ReadOnlyPaths = [
 	"/bin/**",
-	"/bin/**",
 	"/boot/**",
 	"/dev/**",
 	"/etc/**",

--- a/sample.toml
+++ b/sample.toml
@@ -6,7 +6,6 @@ Name = "nginx"
 # read only paths for the container
 ReadOnlyPaths = [
 	"/bin/**",
-	"/bin/**",
 	"/boot/**",
 	"/dev/**",
 	"/etc/**",


### PR DESCRIPTION
`"/bin/**"` is present twice in sample.toml and README.md.

Signed-off-by: Thomas Sjögren konstruktoid@users.noreply.github.com
