### PR TITLE
Cap support

### DIFF
--- a/apparmor/apparmor.go
+++ b/apparmor/apparmor.go
@@ -13,9 +13,10 @@ import (
 // ProfileConfig defines the config for an
 // apparmor profile to be generated from.
 type ProfileConfig struct {
-	Name       string
-	Filesystem FsConfig
-	Network    NetConfig
+	Name         string
+	Filesystem   FsConfig
+	Network      NetConfig
+	Capabilities CapConfig
 
 	Imports      []string
 	InnerImports []string
@@ -36,6 +37,13 @@ type FsConfig struct {
 type NetConfig struct {
 	Raw    bool
 	Packet bool
+}
+
+// CapConfig defines the allowed or denied kernel capabilities
+// for a profile.
+type CapConfig struct {
+	Allow []string
+	Deny  []string
 }
 
 // Generate uses the baseTemplate to generate an apparmor profile

--- a/apparmor/template.go
+++ b/apparmor/template.go
@@ -14,7 +14,6 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
 {{end}}
 {{if .Network.Packet}}{{else}}  deny network packet,
 {{end}}
-  capability,
   file,
   umount,
 
@@ -27,6 +26,10 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
 {{range $value := .Filesystem.AllowExec}}  {{$value}} ix,
 {{end}}
 {{range $value := .Filesystem.DenyExec}}  deny {{$value}} mrwklx,
+{{end}}
+{{range $value := .Capabilities.Allow}}  capability {{$value}},
+{{end}}
+{{range $value := .Capabilities.Deny}}  deny capability {{$value}},
 {{end}}
 
   deny @{PROC}/{*,**^[0-9*],sys/kernel/shm*} wkx,

--- a/sample.toml
+++ b/sample.toml
@@ -46,6 +46,16 @@ DenyExec = [
 	"/usr/bin/top"
 ]
 
+# allowed capabilities
+[Capabilities]
+Allow = [
+	"chown",
+	"dac_override",
+	"setuid",
+	"setgid",
+	"net_bind_service"
+]
+
 [Network]
 # if you don't need to ping in a container, you can probably
 # set Raw to false and deny network raw


### PR DESCRIPTION
Adding support for .Capabilities.Allow and .Capabilities.Deny. 

I haven't updated the docs yet, but wouldn't it be smoother to maintain if there only was a short mention and links from the `README.md` to `sample.toml` and the `docker-nginx` profile instead?
