### PR TITLE
add make install, build -a

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 # Set an output prefix, which is the local directory if not specified
 PREFIX?=$(shell pwd)
 
-.PHONY: clean all fmt vet lint build test
+.PHONY: clean all fmt vet lint build test install
 .DEFAULT: default
 
-all: clean build fmt lint test vet
+all: clean build fmt lint test vet install
 
 build:
 	@echo "+ $@"
-	@go build -v ./...
+	@go build -a -v ./...
 
 fmt:
 	@echo "+ $@"
@@ -29,3 +29,7 @@ vet:
 clean:
 	@echo "+ $@"
 	@rm -rf bane
+
+install:
+	@echo "+ $@"
+	@go install -v .


### PR DESCRIPTION
Adds `install` to the Makefile and I had some cache issues when compiling for the X:th time in a row so I had to change `make build` to `go build -a -v`.
Hopefully useful.

Signed-off-by: Thomas Sjögren konstruktoid@users.noreply.github.com
