### PR TITLE
add capability when blacklisting, changes profile output

### DIFF
--- a/apparmor/template.go
+++ b/apparmor/template.go
@@ -27,11 +27,12 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
 {{end}}
 {{range $value := .Filesystem.DenyExec}}  deny {{$value}} mrwklx,
 {{end}}
-{{range $value := .Capabilities.Allow}}  capability {{$value}},
-{{end}}
+{{if .Capabilities.Deny}}
+  capability,
 {{range $value := .Capabilities.Deny}}  deny capability {{$value}},
-{{end}}
-
+{{end}}{{else}}
+{{range $value := .Capabilities.Allow}}  capability {{$value}},
+{{end}}{{end}}
   deny @{PROC}/{*,**^[0-9*],sys/kernel/shm*} wkx,
   deny @{PROC}/sysrq-trigger rwklx,
   deny @{PROC}/mem rwklx,

--- a/docker-nginx-sample
+++ b/docker-nginx-sample
@@ -42,13 +42,12 @@ profile docker-nginx-sample flags=(attach_disconnected,mediate_deleted) {
   deny /bin/sh mrwklx,
   deny /usr/bin/top mrwklx,
 
+
   capability chown,
   capability dac_override,
   capability setuid,
   capability setgid,
   capability net_bind_service,
-
-
 
   deny @{PROC}/{*,**^[0-9*],sys/kernel/shm*} wkx,
   deny @{PROC}/sysrq-trigger rwklx,


### PR DESCRIPTION
When for some reason people are blacklisting capabilities, we need to add `capability` and then ignore .Capabilities.Allow.

See https://gist.github.com/konstruktoid/1b4fe850c04981275137 for example.

Signed-off-by: Thomas Sjögren konstruktoid@users.noreply.github.com
