### PR TITLE
network protocol support

### DIFF
--- a/apparmor/apparmor.go
+++ b/apparmor/apparmor.go
@@ -34,9 +34,11 @@ type FsConfig struct {
 // NetConfig defines the network options for a profile.
 // For example you probably don't need NetworkRaw if your
 // application doesn't `ping`.
+// Currently limited to AppArmor 2.3-2.6 rules.
 type NetConfig struct {
-	Raw    bool
-	Packet bool
+	Raw       bool
+	Packet    bool
+	Protocols []string
 }
 
 // CapConfig defines the allowed or denied kernel capabilities

--- a/apparmor/template.go
+++ b/apparmor/template.go
@@ -9,7 +9,11 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
 {{range $value := .InnerImports}}  {{$value}}
 {{end}}
 
+{{if .Network.Protocols}}
+{{range $value := .Network.Protocols}}  network inet {{$value}},
+{{end}}{{else}}
   network,
+{{end}}
 {{if .Network.Raw}}{{else}}  deny network raw,
 {{end}}
 {{if .Network.Packet}}{{else}}  deny network packet,

--- a/docker-nginx-sample
+++ b/docker-nginx-sample
@@ -6,7 +6,11 @@ profile docker-nginx-sample flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
 
 
-  network,
+
+  network inet tcp,
+  network inet udp,
+  network inet icmp,
+
   deny network raw,
 
   deny network packet,

--- a/sample.toml
+++ b/sample.toml
@@ -61,3 +61,8 @@ Allow = [
 # set Raw to false and deny network raw
 Raw = false
 Packet = false
+Protocols = [
+	"tcp",
+	"udp",
+	"icmp"
+]


### PR DESCRIPTION
Basic network protocol support, if none is set `network` is used. 
Signed-off-by: Thomas Sjögren konstruktoid@users.noreply.github.com
