### PR TITLE
apparmor: fix template syntax error

### DIFF
--- a/apparmor/template.go
+++ b/apparmor/template.go
@@ -37,7 +37,8 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
 {{end}}{{else}}
 {{range $value := .Capabilities.Allow}}  capability {{$value}},
 {{end}}{{end}}
-  deny @{PROC}/{*,**^[0-9*],sys/kernel/shm*} wkx,
+  deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)
+  deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** w,
   deny @{PROC}/sysrq-trigger rwklx,
   deny @{PROC}/mem rwklx,
   deny @{PROC}/kmem rwklx,

--- a/apparmor/template.go
+++ b/apparmor/template.go
@@ -39,6 +39,7 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
 {{end}}{{end}}
   deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)
   deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** w,
+  deny @{PROC}/sys/kernel/{?,??,[^s][^h][^m]**} w,  # deny everything except shm* in /proc/sys/kernel/
   deny @{PROC}/sysrq-trigger rwklx,
   deny @{PROC}/mem rwklx,
   deny @{PROC}/kmem rwklx,


### PR DESCRIPTION
ERROR: Syntax Error: Invalid Regex @{PROC}/{_,__^[0-9_],sys/kernel/shm*}
